### PR TITLE
Implement Metronic login pages

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -16,7 +16,7 @@ class AuthenticatedSessionController extends Controller
      */
     public function create(): View
     {
-        return view('auth.login');
+        return view('metronic.auth.login');
     }
 
     /**

--- a/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -15,7 +15,7 @@ class PasswordResetLinkController extends Controller
      */
     public function create(): View
     {
-        return view('auth.forgot-password');
+        return view('metronic.auth.forgot-password');
     }
 
     /**

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -5,7 +5,6 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use App\Models\User;
 
 class Role extends Model
 {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,7 +6,6 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use App\Models\Role;
 
 class User extends Authenticatable
 {

--- a/app/View/Components/MetronicLayout.php
+++ b/app/View/Components/MetronicLayout.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\View\Components;
+
+use Illuminate\View\Component;
+use Illuminate\View\View;
+
+class MetronicLayout extends Component
+{
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View
+    {
+        return view('metronic.layout');
+    }
+}

--- a/resources/views/metronic/auth/forgot-password.blade.php
+++ b/resources/views/metronic/auth/forgot-password.blade.php
@@ -1,0 +1,39 @@
+<x-metronic-layout>
+    <div class="d-flex flex-column flex-root" id="kt_app_root">
+        <div class="d-flex flex-column flex-lg-row flex-column-fluid">
+            <div class="d-flex flex-column flex-lg-row-fluid w-lg-50 p-10 order-2 order-lg-1">
+                <div class="d-flex flex-center flex-column flex-lg-row-fluid">
+                    <div class="w-lg-500px p-10">
+                        <form method="POST" action="{{ route('password.email') }}" class="form w-100" novalidate="novalidate" id="kt_forgot_password_form">
+                            @csrf
+                            <div class="text-center mb-11">
+                                <h1 class="text-gray-900 fw-bolder mb-3">Forgot Password</h1>
+                                <div class="text-gray-500 fw-semibold fs-6">Enter your email to reset your password.</div>
+                            </div>
+                            <div class="fv-row mb-8">
+                                <input id="email" class="form-control bg-transparent" type="email" name="email" :value="old('email')" required autofocus placeholder="Email" />
+                                <x-input-error :messages="$errors->get('email')" class="mt-2" />
+                            </div>
+                            <div class="d-grid mb-10">
+                                <button type="submit" id="kt_password_reset_submit" class="btn btn-primary">
+                                    <span class="indicator-label">Send Reset Link</span>
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+            <div class="d-flex flex-lg-row-fluid w-lg-50 bgi-size-cover bgi-position-center order-1 order-lg-2" style="background-image: url('{{ asset('metronic/assets/media/misc/auth-bg.png') }}')">
+                <div class="d-flex flex-column flex-center py-7 py-lg-15 px-5 px-md-15 w-100">
+                    <a href="/" class="mb-0 mb-lg-12">
+                        <img alt="Logo" src="{{ asset('metronic/assets/media/logos/custom-1.png') }}" class="h-60px h-lg-75px" />
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    @push('scripts')
+        <script src="{{ asset('metronic/assets/js/custom/authentication/reset-password/reset-password.js') }}"></script>
+    @endpush
+</x-metronic-layout>

--- a/resources/views/metronic/auth/login.blade.php
+++ b/resources/views/metronic/auth/login.blade.php
@@ -1,0 +1,48 @@
+<x-metronic-layout>
+    <div class="d-flex flex-column flex-root" id="kt_app_root">
+        <div class="d-flex flex-column flex-lg-row flex-column-fluid">
+            <div class="d-flex flex-column flex-lg-row-fluid w-lg-50 p-10 order-2 order-lg-1">
+                <div class="d-flex flex-center flex-column flex-lg-row-fluid">
+                    <div class="w-lg-500px p-10">
+                        <form method="POST" action="{{ route('login') }}" class="form w-100" novalidate="novalidate" id="kt_sign_in_form">
+                            @csrf
+                            <div class="text-center mb-11">
+                                <h1 class="text-gray-900 fw-bolder mb-3">Sign In</h1>
+                            </div>
+                            <div class="fv-row mb-8">
+                                <input id="email" class="form-control bg-transparent" type="email" name="email" :value="old('email')" required autofocus placeholder="Email" />
+                                <x-input-error :messages="$errors->get('email')" class="mt-2" />
+                            </div>
+                            <div class="fv-row mb-3">
+                                <input id="password" class="form-control bg-transparent" type="password" name="password" required placeholder="Password" autocomplete="current-password" />
+                                <x-input-error :messages="$errors->get('password')" class="mt-2" />
+                            </div>
+                            <div class="d-flex flex-stack flex-wrap gap-3 fs-base fw-semibold mb-8">
+                                <div></div>
+                                @if (Route::has('password.request'))
+                                    <a class="link-primary" href="{{ route('password.request') }}">Forgot Password ?</a>
+                                @endif
+                            </div>
+                            <div class="d-grid mb-10">
+                                <button type="submit" id="kt_sign_in_submit" class="btn btn-primary">
+                                    <span class="indicator-label">Sign In</span>
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+            <div class="d-flex flex-lg-row-fluid w-lg-50 bgi-size-cover bgi-position-center order-1 order-lg-2" style="background-image: url('{{ asset('metronic/assets/media/misc/auth-bg.png') }}')">
+                <div class="d-flex flex-column flex-center py-7 py-lg-15 px-5 px-md-15 w-100">
+                    <a href="/" class="mb-0 mb-lg-12">
+                        <img alt="Logo" src="{{ asset('metronic/assets/media/logos/custom-1.png') }}" class="h-60px h-lg-75px" />
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    @push('scripts')
+        <script src="{{ asset('metronic/assets/js/custom/authentication/sign-in/general.js') }}"></script>
+    @endpush
+</x-metronic-layout>

--- a/resources/views/metronic/layout.blade.php
+++ b/resources/views/metronic/layout.blade.php
@@ -1,1 +1,21 @@
-<!-- Metronic layout placeholder -->
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ config('app.name', 'Laravel') }}</title>
+
+    <!-- Metronic Global Stylesheets Bundle -->
+    <link rel="stylesheet" href="{{ asset('metronic/assets/plugins/global/plugins.bundle.css') }}">
+    <link rel="stylesheet" href="{{ asset('metronic/assets/css/style.bundle.css') }}">
+</head>
+<body id="kt_body" class="app-blank">
+    {{ $slot }}
+
+    <!-- Metronic Global Javascript Bundle -->
+    <script src="{{ asset('metronic/assets/plugins/global/plugins.bundle.js') }}"></script>
+    <script src="{{ asset('metronic/assets/js/scripts.bundle.js') }}"></script>
+
+    @stack('scripts')
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement generic Metronic layout
- create login and forgot password pages using Metronic template
- add `MetronicLayout` blade component
- point auth controllers to new views
- run Pint

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_6841f0cb68048328a95d27c00b368276