### PR TITLE
Add role seeder and admin user

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,8 @@
 namespace Database\Seeders;
 
 use App\Models\User;
+use App\Models\Role;
+use Illuminate\Support\Facades\Hash;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -15,9 +17,15 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
+        $this->call(RoleSeeder::class);
+
+        $adminRole = Role::where('name', 'Administrador')->first();
+
         User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+            'name' => 'André Jálisson',
+            'email' => 'andrejalisson@sgroupnacional.com.br',
+            'password' => Hash::make('Kk@31036700#'),
+            'role_id' => $adminRole?->id,
         ]);
     }
 }

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Role;
+use Illuminate\Database\Seeder;
+
+class RoleSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $roles = [
+            '24 Horas',
+            'Consultor',
+            'Administrador',
+        ];
+
+        foreach ($roles as $role) {
+            Role::firstOrCreate(['name' => $role]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add RoleSeeder with default roles
- seed default admin user in DatabaseSeeder

## Testing
- `composer test`
- `php artisan migrate --force`
- `php artisan db:seed --force`


------
https://chatgpt.com/codex/tasks/task_e_6841f72223c8832898277b8d7b466b00