### PR TITLE
Localize email column in users table

### DIFF
--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -12,7 +12,7 @@
                     <thead>
                         <tr>
                             <th>Nome</th>
-                            <th>Email</th>
+                            <th>{{ __('Email') }}</th>
                             <th>Grupo</th>
                             <th>Criado em</th>
                         </tr>


### PR DESCRIPTION
## Summary
- use translation for Email header in Users list

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684204b8cd708328959baf22435fb1da