### PR TITLE
Implement Role CRUD

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -17,6 +17,50 @@ class RoleController extends Controller
         return view('roles.index', compact('roles'));
     }
 
+    public function create(): View
+    {
+        return view('roles.create');
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255', 'unique:roles,name'],
+        ]);
+
+        Role::create($validated);
+
+        return redirect()->route('roles.index');
+    }
+
+    public function show(Role $role): View
+    {
+        return view('roles.show', compact('role'));
+    }
+
+    public function edit(Role $role): View
+    {
+        return view('roles.edit', compact('role'));
+    }
+
+    public function update(Request $request, Role $role)
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255', 'unique:roles,name,' . $role->id],
+        ]);
+
+        $role->update($validated);
+
+        return redirect()->route('roles.index');
+    }
+
+    public function destroy(Role $role)
+    {
+        $role->delete();
+
+        return redirect()->route('roles.index');
+    }
+
     public function listar(Request $request): JsonResponse
     {
         $columns = [
@@ -54,9 +98,11 @@ class RoleController extends Controller
             $nested['id']   = $role->id;
             $nested['nome'] = $role->name;
             $nested['status'] = '<span class="badge badge-success">Ativo</span>';
+            $show   = route('roles.show', $role->id);
+            $edit   = route('roles.edit', $role->id);
             $nested['acoes'] = "<div class='text-end'>".
-                "<a href='/roles/{$role->id}' class='btn btn-sm btn-info me-1'>Visualizar</a>".
-                "<a href='/roles/{$role->id}/edit' class='btn btn-sm btn-warning'>Editar</a>".
+                "<a href='{$show}' class='btn btn-sm btn-info me-1'>Visualizar</a>".
+                "<a href='{$edit}' class='btn btn-sm btn-warning'>Editar</a>".
                 "</div>";
 
             $data[] = $nested;

--- a/database/factories/RoleFactory.php
+++ b/database/factories/RoleFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Role>
+ */
+class RoleFactory extends Factory
+{
+    protected $model = \App\Models\Role::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->word(),
+        ];
+    }
+}

--- a/resources/views/roles/create.blade.php
+++ b/resources/views/roles/create.blade.php
@@ -1,0 +1,48 @@
+@extends('template.app')
+
+@section('css')
+@endsection
+
+@section('corpo')
+    <div class="d-flex flex-column flex-root" id="kt_app_root">
+        <div class="d-flex flex-column flex-lg-row flex-column-fluid">
+            <div class="d-flex flex-column flex-lg-row-fluid w-lg-50 p-10 order-2 order-lg-1">
+                <div class="d-flex flex-center flex-column flex-lg-row-fluid">
+                    <div class="w-lg-500px p-10">
+                        <form method="POST" action="{{ route('roles.store') }}" class="form w-100" novalidate="novalidate">
+                            @csrf
+                            <div class="text-center mb-11">
+                                <h1 class="text-gray-900 fw-bolder mb-3">Novo Grupo</h1>
+                            </div>
+                            <div class="fv-row mb-8">
+                                <input class="form-control bg-transparent" type="text" name="name" value="{{ old('name') }}" required placeholder="Nome" />
+                                <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                            </div>
+                            <div class="d-grid mb-10">
+                                <button type="submit" class="btn btn-primary">
+                                    <span class="indicator-label">Salvar</span>
+                                </button>
+                            </div>
+                            <div class="text-center">
+                                <a href="{{ route('roles.index') }}" class="btn btn-light">Cancelar</a>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+            <div class="d-flex flex-lg-row-fluid w-lg-50 bgi-size-cover bgi-position-center order-1 order-lg-2" style="background-image: url('{{ asset('metronic/assets/media/misc/auth-bg.png') }}')">
+                <div class="d-flex flex-column flex-center py-7 py-lg-15 px-5 px-md-15 w-100">
+                    <a href="/" class="mb-0 mb-lg-12">
+                        <img alt="Logo" src="{{ asset('metronic/assets/media/logos/custom-1.png') }}" class="h-60px h-lg-75px" />
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@section('js')
+@endsection
+
+@section('script')
+@endsection

--- a/resources/views/roles/edit.blade.php
+++ b/resources/views/roles/edit.blade.php
@@ -1,0 +1,49 @@
+@extends('template.app')
+
+@section('css')
+@endsection
+
+@section('corpo')
+    <div class="d-flex flex-column flex-root" id="kt_app_root">
+        <div class="d-flex flex-column flex-lg-row flex-column-fluid">
+            <div class="d-flex flex-column flex-lg-row-fluid w-lg-50 p-10 order-2 order-lg-1">
+                <div class="d-flex flex-center flex-column flex-lg-row-fluid">
+                    <div class="w-lg-500px p-10">
+                        <form method="POST" action="{{ route('roles.update', $role) }}" class="form w-100" novalidate="novalidate">
+                            @csrf
+                            @method('PUT')
+                            <div class="text-center mb-11">
+                                <h1 class="text-gray-900 fw-bolder mb-3">Editar Grupo</h1>
+                            </div>
+                            <div class="fv-row mb-8">
+                                <input class="form-control bg-transparent" type="text" name="name" value="{{ old('name', $role->name) }}" required placeholder="Nome" />
+                                <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                            </div>
+                            <div class="d-grid mb-10">
+                                <button type="submit" class="btn btn-primary">
+                                    <span class="indicator-label">Salvar</span>
+                                </button>
+                            </div>
+                            <div class="text-center">
+                                <a href="{{ route('roles.index') }}" class="btn btn-light">Cancelar</a>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+            <div class="d-flex flex-lg-row-fluid w-lg-50 bgi-size-cover bgi-position-center order-1 order-lg-2" style="background-image: url('{{ asset('metronic/assets/media/misc/auth-bg.png') }}')">
+                <div class="d-flex flex-column flex-center py-7 py-lg-15 px-5 px-md-15 w-100">
+                    <a href="/" class="mb-0 mb-lg-12">
+                        <img alt="Logo" src="{{ asset('metronic/assets/media/logos/custom-1.png') }}" class="h-60px h-lg-75px" />
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@section('js')
+@endsection
+
+@section('script')
+@endsection

--- a/resources/views/roles/show.blade.php
+++ b/resources/views/roles/show.blade.php
@@ -1,0 +1,41 @@
+@extends('template.app')
+
+@section('css')
+@endsection
+
+@section('corpo')
+    <div class="d-flex flex-column flex-root" id="kt_app_root">
+        <div class="d-flex flex-column flex-lg-row flex-column-fluid">
+            <div class="d-flex flex-column flex-lg-row-fluid w-lg-50 p-10 order-2 order-lg-1">
+                <div class="d-flex flex-center flex-column flex-lg-row-fluid">
+                    <div class="w-lg-500px p-10">
+                        <form class="form w-100">
+                            <div class="text-center mb-11">
+                                <h1 class="text-gray-900 fw-bolder mb-3">Visualizar Grupo</h1>
+                            </div>
+                            <div class="fv-row mb-8">
+                                <input class="form-control bg-transparent" type="text" value="{{ $role->name }}" disabled placeholder="Nome" />
+                            </div>
+                            <div class="text-center">
+                                <a href="{{ route('roles.index') }}" class="btn btn-light">Voltar</a>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+            <div class="d-flex flex-lg-row-fluid w-lg-50 bgi-size-cover bgi-position-center order-1 order-lg-2" style="background-image: url('{{ asset('metronic/assets/media/misc/auth-bg.png') }}')">
+                <div class="d-flex flex-column flex-center py-7 py-lg-15 px-5 px-md-15 w-100">
+                    <a href="/" class="mb-0 mb-lg-12">
+                        <img alt="Logo" src="{{ asset('metronic/assets/media/logos/custom-1.png') }}" class="h-60px h-lg-75px" />
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@section('js')
+@endsection
+
+@section('script')
+@endsection

--- a/tests/Feature/RoleTest.php
+++ b/tests/Feature/RoleTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RoleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_role_can_be_created(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('roles.store'), [
+            'name' => 'Test Role',
+        ]);
+
+        $response->assertRedirect(route('roles.index', absolute: false));
+        $this->assertDatabaseHas('roles', ['name' => 'Test Role']);
+    }
+
+    public function test_role_can_be_updated(): void
+    {
+        $user = User::factory()->create();
+        $role = Role::factory()->create(['name' => 'Old Name']);
+
+        $response = $this->actingAs($user)->put(route('roles.update', $role), [
+            'name' => 'New Name',
+        ]);
+
+        $response->assertRedirect(route('roles.index', absolute: false));
+        $this->assertDatabaseHas('roles', ['id' => $role->id, 'name' => 'New Name']);
+    }
+
+    public function test_role_can_be_deleted(): void
+    {
+        $user = User::factory()->create();
+        $role = Role::factory()->create();
+
+        $response = $this->actingAs($user)->delete(route('roles.destroy', $role));
+
+        $response->assertRedirect(route('roles.index', absolute: false));
+        $this->assertDatabaseMissing('roles', ['id' => $role->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- add full CRUD actions in `RoleController`
- provide blade templates for roles
- fix DataTable action links for roles
- add `RoleFactory` and feature test coverage

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470826db308328a707a6e5b892ae56