### PR TITLE
Add modals for user view/edit

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -84,6 +84,18 @@ class UserController extends Controller{
         return response()->json(['status' => $user->status]);
     }
 
+    public function viewModal(User $user): View
+    {
+        return view('users.partials.view-modal', compact('user'));
+    }
+
+    public function editModal(User $user): View
+    {
+        $roles = Role::all();
+
+        return view('users.partials.edit-modal', compact('user', 'roles'));
+    }
+
     public function listar(Request $request){
         $columns = [
             0 => 'users.id',
@@ -146,8 +158,8 @@ class UserController extends Controller{
             $token = csrf_token();
             $nested['acoes']    = "
             <div class='text-end'>
-                <a href='/users/{$item->id}' class='btn btn-sm btn-info me-1'>Visualizar</a>
-                <a href='/users/{$item->id}/edit' class='btn btn-sm btn-warning me-1'>Editar</a>
+                <button type='button' class='btn btn-sm btn-info me-1 view-user' data-id='{$item->id}'>Visualizar</button>
+                <button type='button' class='btn btn-sm btn-warning me-1 edit-user' data-id='{$item->id}'>Editar</button>
                 <form action='/users/{$item->id}' method='POST' class='d-inline' onsubmit=\"return confirm('Tem certeza que deseja excluir este usuário?');\">
                     <input type='hidden' name='_token' value='{$token}'>
                     <input type='hidden' name='_method' value='DELETE'>

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -47,6 +47,16 @@
             </table>
         </div>
     </div>
+    <div class="modal fade" id="modalViewUser" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content"></div>
+        </div>
+    </div>
+    <div class="modal fade" id="modalEditUser" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content"></div>
+        </div>
+    </div>
 @endsection
 
 @section('js')
@@ -118,6 +128,40 @@
                             instance.hide({transitionOut: 'fadeOut'}, toast, 'button');
                         }]
                     ]
+                });
+            });
+
+            $(document).on('click', '.view-user', function () {
+                const id = $(this).data('id');
+                $('#modalViewUser .modal-content').load('/users/' + id + '/view-modal', function () {
+                    const modal = new bootstrap.Modal(document.getElementById('modalViewUser'));
+                    modal.show();
+                });
+            });
+
+            $(document).on('click', '.edit-user', function () {
+                const id = $(this).data('id');
+                $('#modalEditUser .modal-content').load('/users/' + id + '/edit-modal', function () {
+                    const modal = new bootstrap.Modal(document.getElementById('modalEditUser'));
+                    modal.show();
+                });
+            });
+
+            $(document).on('submit', '#modalEditUser form', function (e) {
+                e.preventDefault();
+                let form = $(this);
+                $.ajax({
+                    url: form.attr('action'),
+                    method: 'POST',
+                    data: form.serialize(),
+                    success: function () {
+                        bootstrap.Modal.getInstance(document.getElementById('modalEditUser')).hide();
+                        tabela.ajax.reload(null, false);
+                        iziToast.success({title: 'Sucesso', message: 'Usuário atualizado'});
+                    },
+                    error: function (xhr) {
+                        $('#modalEditUser .modal-content').html(xhr.responseText);
+                    }
                 });
             });
         });

--- a/resources/views/users/partials/edit-modal.blade.php
+++ b/resources/views/users/partials/edit-modal.blade.php
@@ -1,0 +1,35 @@
+<div class="modal-header">
+    <h5 class="modal-title">Editar Usuário</h5>
+    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+</div>
+<form id="editUserForm" method="POST" action="{{ route('users.update', $user) }}">
+    @csrf
+    @method('PUT')
+    <div class="modal-body">
+        <div class="mb-3">
+            <input class="form-control" type="text" name="name" value="{{ old('name', $user->name) }}" required placeholder="Nome" />
+            <x-input-error :messages="$errors->get('name')" class="mt-2" />
+        </div>
+        <div class="mb-3">
+            <input class="form-control" type="email" name="email" value="{{ old('email', $user->email) }}" required placeholder="E-mail" />
+            <x-input-error :messages="$errors->get('email')" class="mt-2" />
+        </div>
+        <div class="mb-3">
+            <input class="form-control" type="password" name="password" placeholder="Senha (deixe em branco para manter)" />
+            <x-input-error :messages="$errors->get('password')" class="mt-2" />
+        </div>
+        <div class="mb-3">
+            <select name="role_id" class="form-select">
+                <option value="">Selecione um grupo</option>
+                @foreach($roles as $role)
+                    <option value="{{ $role->id }}" @selected(old('role_id', $user->role_id) == $role->id)>{{ $role->name }}</option>
+                @endforeach
+            </select>
+            <x-input-error :messages="$errors->get('role_id')" class="mt-2" />
+        </div>
+    </div>
+    <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <button type="submit" class="btn btn-primary">Salvar</button>
+    </div>
+</form>

--- a/resources/views/users/partials/view-modal.blade.php
+++ b/resources/views/users/partials/view-modal.blade.php
@@ -1,0 +1,18 @@
+<div class="modal-header">
+    <h5 class="modal-title">Visualizar Usuário</h5>
+    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+</div>
+<div class="modal-body">
+    <div class="mb-3">
+        <input class="form-control" type="text" value="{{ $user->name }}" disabled placeholder="Nome" />
+    </div>
+    <div class="mb-3">
+        <input class="form-control" type="email" value="{{ $user->email }}" disabled placeholder="E-mail" />
+    </div>
+    <div class="mb-3">
+        <input class="form-control" type="text" value="{{ optional($user->role)->name }}" disabled placeholder="Grupo" />
+    </div>
+</div>
+<div class="modal-footer">
+    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,8 @@ Route::middleware('auth')->group(function () {
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 
     Route::resource('users', UserController::class);
+    Route::get('users/{user}/view-modal', [UserController::class, 'viewModal'])->name('users.view-modal');
+    Route::get('users/{user}/edit-modal', [UserController::class, 'editModal'])->name('users.edit-modal');
     Route::match(['post', 'put'], 'users/{user}/status', [UserController::class, 'toggleStatus'])->name('users.toggle-status');
     Route::post('users/listar', [UserController::class, 'listar'])->name('users.listar');
 


### PR DESCRIPTION
## Summary
- provide modal endpoints for users
- create partial views for modal content
- switch DataTable actions to modal buttons
- load user modals via AJAX and submit edit form asynchronously

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68470fdd09808328a59670655f467309